### PR TITLE
refactor to provide organizationId together with initiativeId in Reward

### DIFF
--- a/src/main/java/it/gov/pagopa/reward/notification/dto/mapper/Initiative2RewardNotificationRuleMapper.java
+++ b/src/main/java/it/gov/pagopa/reward/notification/dto/mapper/Initiative2RewardNotificationRuleMapper.java
@@ -5,6 +5,7 @@ import it.gov.pagopa.reward.notification.model.RewardNotificationRule;
 import it.gov.pagopa.reward.notification.service.utils.Utils;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.function.Function;
 
 @Service
@@ -21,6 +22,7 @@ public class Initiative2RewardNotificationRuleMapper implements Function<Initiat
                 .organizationFiscalCode(initiativeRefund2StoreDTO.getOrganizationVat())
                 .accumulatedAmount(initiativeRefund2StoreDTO.getRefundRule().getAccumulatedAmount())
                 .timeParameter(initiativeRefund2StoreDTO.getRefundRule().getTimeParameter())
+                .updateDate(LocalDateTime.now())
                 .build();
         if (out.getAccumulatedAmount() != null && out.getAccumulatedAmount().getRefundThreshold() != null) {
             out.getAccumulatedAmount().setRefundThresholdCents(Utils.euro2Cents(out.getAccumulatedAmount().getRefundThreshold()));

--- a/src/main/java/it/gov/pagopa/reward/notification/dto/trx/RefundInfo.java
+++ b/src/main/java/it/gov/pagopa/reward/notification/dto/trx/RefundInfo.java
@@ -15,5 +15,12 @@ import java.util.Map;
 @Builder
 public class RefundInfo {
     private List<TransactionProcessed> previousTrxs;
-    private Map<String, BigDecimal> previousRewards;
+    private Map<String, PreviousReward> previousRewards;
+
+    @Data @AllArgsConstructor @NoArgsConstructor
+    public static class PreviousReward {
+        private String initiativeId;
+        private String organizationId;
+        private BigDecimal accruedReward;
+    }
 }

--- a/src/main/java/it/gov/pagopa/reward/notification/dto/trx/Reward.java
+++ b/src/main/java/it/gov/pagopa/reward/notification/dto/trx/Reward.java
@@ -26,6 +26,9 @@ public class Reward {
     /** True, if the reward has been capped due to weekly threshold */
     private boolean weeklyCapped;
 
+    /** True if is the trx has not more reward for the current initiative */
+    private boolean isCompleteRefund;
+
     /** Counters */
     private RewardCounters counters = new RewardCounters();
 

--- a/src/main/java/it/gov/pagopa/reward/notification/model/RewardNotificationRule.java
+++ b/src/main/java/it/gov/pagopa/reward/notification/model/RewardNotificationRule.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
@@ -22,4 +23,5 @@ public class RewardNotificationRule {
     private AccumulatedAmountDTO accumulatedAmount;
     private TimeParameterDTO timeParameter;
     private String organizationFiscalCode;
+    private LocalDateTime updateDate;
 }

--- a/src/test/java/it/gov/pagopa/reward/notification/test/fakers/RewardNotificationRuleFaker.java
+++ b/src/test/java/it/gov/pagopa/reward/notification/test/fakers/RewardNotificationRuleFaker.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.ObjectUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class RewardNotificationRuleFaker {
     /** It will return an example of {@link RewardNotificationRule}. Providing a bias, it will return a pseudo-casual object */
@@ -28,6 +29,7 @@ public class RewardNotificationRuleFaker {
         out.initiativeName("NAME_%d_%s".formatted(bias, fakeValuesService.bothify("???")));
         out.endDate(LocalDate.now());
         out.organizationId("ORGANIZATION_ID_%d_%s".formatted(bias, fakeValuesService.bothify("???")));
+        out.updateDate(LocalDateTime.now());
 
         AccumulatedAmountDTO accumulatedAmount = AccumulatedAmountDTO.builder()
                 .accumulatedType(AccumulatedAmountDTO.AccumulatedTypeEnum.THRESHOLD_REACHED)


### PR DESCRIPTION
fix inside reward_rules:
	refundInfo.getPreviousRewards().get("ID_0_ssx").getAccruedReward()
	fix package it.gov.pagopa.reward.dto.Reward into it.gov.pagopa.reward.dto.trx.Reward
	fix new Reward invocation adding initiativeId and organizationId
clear transactions or fix refundInfo structure