### PR TITLE
fix: [IPD-2343] Change incoming transaction filtering logic

### DIFF
--- a/src/main/java/it/gov/pagopa/reward/notification/service/rewards/RewardsMediatorServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/reward/notification/service/rewards/RewardsMediatorServiceImpl.java
@@ -87,7 +87,7 @@ public class RewardsMediatorServiceImpl extends BaseKafkaBlockingPartitionConsum
     @Override
     protected Mono<List<Rewards>> execute(RewardTransactionDTO payload, Message<String> message, Map<String, Object> ctx) {
         return Mono.just(payload)
-				.filter(t -> !TrxConstants.TRX_STATUS_AUTHORIZED.equals(t.getStatus()) && !TrxConstants.TRX_STATUS_CANCELLED.equals(t.getStatus()))
+				.filter(t -> TrxConstants.TRX_STATUS_REWARDED.equals(t.getStatus()))
                 .flatMapMany(this::readRewards)
                 .flatMap(this::checkDuplicateReward)
                 .flatMap(r -> retrieveInitiativeAndEvaluate(r, message))

--- a/src/main/java/it/gov/pagopa/reward/notification/utils/TrxConstants.java
+++ b/src/main/java/it/gov/pagopa/reward/notification/utils/TrxConstants.java
@@ -5,5 +5,6 @@ public final class TrxConstants {
     private TrxConstants() {}
 
     public static final String TRX_STATUS_AUTHORIZED = "AUTHORIZED";
+    public static final String TRX_STATUS_REWARDED = "REWARDED";
     public static final String TRX_STATUS_CANCELLED = "CANCELLED";
 }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

[IDP-2343](https://pagopa.atlassian.net/browse/IDP-2343)

#### List of Changes
<!--- Describe your changes in detail -->

Update the incoming transaction filtering logic to only accept transactions with the status 'REWARDED'.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
    - [X] Unit
    - [ ] Integration (Narrow)
- Post-Deploy Test
    - [X] Isolated Microservice
    - [ ] Broader Integration
    - [ ] Acceptance
    - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[IDP-2343]: https://pagopa.atlassian.net/browse/IDP-2343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ